### PR TITLE
feat: add support for deploy stacks till install dependencies

### DIFF
--- a/pickyhelpers/commands.go
+++ b/pickyhelpers/commands.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 )
 
-func RunYarnInstall(path ...string) error {
+func InstallDependencies(pkgManager string, path ...string) error {
 	filePath := filepath.Join(path...)
-	err := RunCommand(filePath, "yarn", "install")
+	err := RunCommand(filePath, pkgManager, "install")
 	return err
 }
 

--- a/pickyhelpers/updatePackageDotJson.go
+++ b/pickyhelpers/updatePackageDotJson.go
@@ -2,16 +2,15 @@ package pickyhelpers
 
 import (
 	"fmt"
-	"os/exec"
 
+	"github.com/wednesday-solutions/picky/utils"
 	"github.com/wednesday-solutions/picky/utils/constants"
 	"github.com/wednesday-solutions/picky/utils/errorhandler"
 	"github.com/wednesday-solutions/picky/utils/fileutils"
 )
 
 func UpdatePackageDotJson(stack, dirName string) error {
-
-	var command string
+	var pkgManager string
 	var dependencies []string
 	var updateCommands []string
 
@@ -24,27 +23,16 @@ func UpdatePackageDotJson(stack, dirName string) error {
 		// convert to mysql
 		dependencies = []string{"mysql2"}
 	}
-
-	err := exec.Command("yarn", "-v").Run()
-	if err != nil {
-		err = exec.Command("npm", "-v").Run()
-		if err != nil {
-			errorhandler.CheckNilErr(fmt.Errorf("Please install 'yarn' or 'npm' in your machine."))
-		} else {
-			command = "npm"
-			updateCommands = []string{"install", "--legacy-peer-deps", "--save"}
-			updateCommands = append(updateCommands, dependencies...)
-		}
-	} else {
-		command = "yarn"
+	pkgManager = utils.IsYarnOrNpmInstalled()
+	if pkgManager == constants.Yarn {
 		updateCommands = []string{"add"}
 		updateCommands = append(updateCommands, dependencies...)
+	} else if pkgManager == constants.Npm {
+		updateCommands = []string{"install", "--legacy-peer-deps", "--save"}
+		updateCommands = append(updateCommands, dependencies...)
 	}
-
-	cmd := exec.Command(command, updateCommands...)
-	cmd.Dir = fmt.Sprintf("%s/%s", fileutils.CurrentDirectory(), dirName)
-	err = cmd.Run()
+	path := fmt.Sprintf("%s/%s", fileutils.CurrentDirectory(), dirName)
+	err := RunCommand(path, pkgManager, updateCommands...)
 	errorhandler.CheckNilErr(err)
-
 	return nil
 }

--- a/prompt/deploy.go
+++ b/prompt/deploy.go
@@ -23,32 +23,34 @@ func PromptDeploy() {
 			}
 			fmt.Printf("%s\n", message)
 		}
+		p.Label = "Do you want to change the selected stacks"
+		p.GoBack = PromptDeploy
 		var stacks []string
-		for {
+		response = p.PromptYesOrNoSelect()
+		if response {
 			stacks = PromptSelectExistingStacks()
-			if len(stacks) > 0 {
-				break
+			nonExistingStacks := pickyhelpers.IsInfraStacksExist(stacks)
+			if len(nonExistingStacks) > 0 {
+				message := "Didn't setup Infrastructure for the following stacks,\n\n"
+				for i, stack := range nonExistingStacks {
+					message = fmt.Sprintf("%s %d. %s\n", message, i+1, stack)
+				}
+				fmt.Printf("%s\n", message)
+				fmt.Printf("Please setup infrastructure first%s\n", errorhandler.Exclamation)
+				PromptSetupInfra()
 			}
 		}
-		nonExistingStacks := pickyhelpers.IsInfraStacksExist(stacks)
-		if len(nonExistingStacks) > 0 {
-			message := "Didn't setup Infrastructure for the following stacks,\n\n"
-			for i, stack := range nonExistingStacks {
-				message = fmt.Sprintf("%s %d. %s\n", message, i+1, stack)
-			}
-			fmt.Printf("%s\n", message)
-			fmt.Printf("Please setup infrastructure first%s\n", errorhandler.Exclamation)
-		} else {
-			_ = PromptEnvironment()
-			err := PromptRunYarnInstall()
-			errorhandler.CheckNilErr(err)
-			fmt.Println("Work in progress. Please stay tuned..!")
-		}
+		_ = PromptEnvironment()
+		err := PromptInstallDependencies()
+		errorhandler.CheckNilErr(err)
+
+		// Let's deploy...
+		fmt.Println("Work in progress. Please stay tuned..!")
 	}
 	PromptHome()
 }
 
-func PromptDeployAfterInfra(services []string) {
+func PromptDeployAfterInfra(services []string, environment string) {
 	var p PromptInput
 	p.Label = "Do you want to deploy your project"
 	p.GoBack = PromptHome
@@ -64,9 +66,10 @@ func PromptDeployAfterInfra(services []string) {
 			p.Label = "Are you sure to deploy the above stacks"
 			response = p.PromptYesOrNoSelect()
 			if response {
-				_ = PromptEnvironment()
-				err := PromptRunYarnInstall()
+				err := PromptInstallDependencies()
 				errorhandler.CheckNilErr(err)
+
+				// Let's deploy...
 				fmt.Println("Work in progress. Please stay tuned..!")
 			}
 		} else {

--- a/prompt/infra.go
+++ b/prompt/infra.go
@@ -26,7 +26,7 @@ func PromptSetupInfra() {
 		environment := PromptEnvironment()
 		err := CreateInfra(stacks, cloudProvider, environment)
 		errorhandler.CheckNilErr(err)
-		PromptDeployAfterInfra(stacks)
+		PromptDeployAfterInfra(stacks, environment)
 	}
 	PromptHome()
 }

--- a/prompt/promptutils.go
+++ b/prompt/promptutils.go
@@ -87,7 +87,15 @@ func PromptSelectExistingStacks() []string {
 	_, _, directories := utils.ExistingStacksDatabasesAndDirectories()
 	p.Items = directories
 	p.Items = append(p.Items, "All")
-	results, responses := p.PromptMultiSelect()
+	var results []string
+	var responses []int
+	for {
+		if len(responses) == 0 {
+			results, responses = p.PromptMultiSelect()
+		} else {
+			break
+		}
+	}
 	for _, respIdx := range responses {
 		if respIdx == len(p.Items)-1 {
 			return directories
@@ -96,22 +104,25 @@ func PromptSelectExistingStacks() []string {
 	return results
 }
 
-func PromptRunYarnInstall() error {
+func PromptInstallDependencies() error {
 	var p PromptInput
-	p.Label = "Can we run 'yarn install'"
+	p.Label = "Can we install dependencies"
 	p.GoBack = PromptHome
-	count := 0
+	count, pkgManager := 0, ""
 	for {
 		response := p.PromptYesOrNoSelect()
 		count++
+		if count == 1 {
+			pkgManager = utils.IsYarnOrNpmInstalled()
+		}
 		if response {
-			err := pickyhelpers.RunYarnInstall()
+			err := pickyhelpers.InstallDependencies(pkgManager)
 			return err
 		}
 		if count == 2 {
 			PromptHome()
 		}
-		err := utils.PrintWarningMessage("You can't deploy without installing 'yarn'")
+		err := utils.PrintWarningMessage("You can't deploy without installing dependencies")
 		errorhandler.CheckNilErr(err)
 	}
 }

--- a/utils/constants/constants.go
+++ b/utils/constants/constants.go
@@ -121,6 +121,8 @@ const (
 	All                      = "All"
 	SstConfigStack           = "sstConfigStack"
 	ExistingDirectories      = "existingDirectories"
+	Yarn                     = "yarn"
+	Npm                      = "npm"
 )
 
 // Docker related files

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"text/template"
 
@@ -350,4 +351,20 @@ func FindStacksByConfigStacks(configStacks []string) []string {
 		}
 	}
 	return stacks
+}
+
+func IsYarnOrNpmInstalled() string {
+	var pkgManager string
+	err := exec.Command(constants.Yarn, "-v").Run()
+	if err != nil {
+		err = exec.Command(constants.Npm, "-v").Run()
+		if err != nil {
+			errorhandler.CheckNilErr(fmt.Errorf("Please install 'yarn' or 'npm' in your machine."))
+		} else {
+			pkgManager = constants.Npm
+		}
+	} else {
+		pkgManager = constants.Yarn
+	}
+	return pkgManager
 }


### PR DESCRIPTION
When installing dependencies either 'yarn' or 'npm' will run. The first preference is 'yarn'. It will show error when both are not installed. It doesn't have deployment part.